### PR TITLE
Provide WSDL access during service creation to enable features like MIME attachments.

### DIFF
--- a/CxfClientGrailsPlugin.groovy
+++ b/CxfClientGrailsPlugin.groovy
@@ -6,7 +6,7 @@ class CxfClientGrailsPlugin {
     private final Long DEFAULT_RECEIVE_TIMEOUT = 60000
 
     // the plugin version
-    def version = "1.2.9"
+    def version = "1.2.9a"
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "1.3.0 > *"
     // the other plugins this plugin depends on
@@ -107,7 +107,8 @@ Used for easily integrating existing or new cxf/jaxb web service client code wit
                     outList << ref("securityInterceptor${cxfClientName}")
                 }
             }
-
+            wsdlURL = client?.wsdl ?: null
+            wsdlServiceName = client?.wsdlServiceName ?: null
             inInterceptors = inList
             outInterceptors = outList
             outFaultInterceptors = outFaultList

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -25,14 +25,14 @@ grails.project.dependency.resolution = {
     }
     dependencies {
         // specify dependencies here under either 'build', 'compile', 'runtime', 'test' or 'provided' scopes eg.
-        compile('org.apache.cxf:cxf-rt-frontend-jaxws:2.3.0') {
+        compile('org.apache.cxf:cxf-rt-frontend-jaxws:2.5.2') {
             excludes 'spring-web'
         }
-        compile('org.apache.cxf:cxf-rt-frontend-jaxrs:2.3.0') {
+        compile('org.apache.cxf:cxf-rt-frontend-jaxrs:2.5.2') {
             excludes 'xmlbeans', 'spring-web', 'spring-core'
         }
-        compile('org.apache.ws.security:wss4j:1.5.9')
-        compile('org.apache.cxf:cxf-rt-ws-security:2.3.0') {
+        compile('org.apache.ws.security:wss4j:1.6.4')
+        compile('org.apache.cxf:cxf-rt-ws-security:2.5.2') {
             excludes 'spring-web'
         }
         // runtime 'mysql:mysql-connector-java:5.1.13'

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,4 +1,4 @@
-<plugin name='cxf-client' version='1.2.9' grailsVersion='1.3.0 &gt; *'>
+<plugin name='cxf-client' version='1.2.9a' grailsVersion='1.3.0 &gt; *'>
   <author>Christian Oestreich</author>
   <authorEmail>acetrike@gmail.com</authorEmail>
   <title>Cxf Client - Support for CXF and JAXB Soap Clients</title>
@@ -20,10 +20,10 @@ Used for easily integrating existing or new cxf/jaxb web service client code wit
   </repositories>
   <dependencies>
     <compile>
-      <dependency group='org.apache.cxf' name='cxf-rt-frontend-jaxws' version='2.3.0' />
-      <dependency group='org.apache.ws.security' name='wss4j' version='1.5.9' />
-      <dependency group='org.apache.cxf' name='cxf-rt-frontend-jaxrs' version='2.3.0' />
-      <dependency group='org.apache.cxf' name='cxf-rt-ws-security' version='2.3.0' />
+      <dependency group='org.apache.cxf' name='cxf-rt-frontend-jaxws' version='2.5.2' />
+      <dependency group='org.apache.ws.security' name='wss4j' version='1.6.4' />
+      <dependency group='org.apache.cxf' name='cxf-rt-frontend-jaxrs' version='2.5.2' />
+      <dependency group='org.apache.cxf' name='cxf-rt-ws-security' version='2.5.2' />
     </compile>
   </dependencies>
   <plugins />

--- a/src/groovy/com/grails/cxf/client/DynamicWebServiceClient.groovy
+++ b/src/groovy/com/grails/cxf/client/DynamicWebServiceClient.groovy
@@ -10,6 +10,8 @@ import org.springframework.context.MessageSource
  */
 class DynamicWebServiceClient implements FactoryBean<Object> {
 
+    String wsdlURL
+    String wsdlServiceName
     Class<?> clientInterface
     Boolean enableDefaultLoggingInterceptors
     def clientPolicyMap = [:]
@@ -29,7 +31,9 @@ class DynamicWebServiceClient implements FactoryBean<Object> {
 before setting the clientInterface=${clientInterface} and 
 serviceEndpointAddress=${serviceEndpointAddress} properties""")
         }
-        webServiceClientFactory.getWebServiceClient(clientInterface,
+        webServiceClientFactory.getWebServiceClient(wsdlURL,
+                                                    wsdlServiceName,
+                                                    clientInterface,
                                                     serviceName,
                                                     serviceEndpointAddress,
                                                     enableDefaultLoggingInterceptors,

--- a/src/groovy/com/grails/cxf/client/WebServiceClientFactory.groovy
+++ b/src/groovy/com/grails/cxf/client/WebServiceClientFactory.groovy
@@ -22,7 +22,7 @@ interface WebServiceClientFactory {
      * @return The web service client.  The returned object will proxy the clientInterface (allowing it
      *         to be injected into other classes as the interface).
      */
-    Object getWebServiceClient(Class<?> clientInterface,
+    Object getWebServiceClient(String wsdlURL, String wsdlServiceName, Class<?> clientInterface,
                                String serviceName,
                                String serviceEndpointAddress,
                                Boolean enableDefaultLoggingInterceptors,


### PR DESCRIPTION
Provide WSDL access during service creation to enable features like MIME attachments.

Also allows configuring wsdlServiceName as it does not seem to be autodetected correctly -- this is more of a workaround until a better solution is created.
