### PR TITLE
Change to support BindingProvider so it can be accessed by Client Code.

### DIFF
--- a/CxfClientGrailsPlugin.groovy
+++ b/CxfClientGrailsPlugin.groovy
@@ -8,7 +8,7 @@ class CxfClientGrailsPlugin {
     private final Long DEFAULT_CONNECTION_TIMEOUT = 30000
     private final Long DEFAULT_RECEIVE_TIMEOUT = 60000
 
-    def version = "1.5.5"
+    def version = "1.5.6"
     def grailsVersion = "1.3.0 > *"
     def pluginExcludes = [
             'grails-app/conf/codenarc.groovy',

--- a/src/groovy/com/grails/cxf/client/WebServiceClientFactoryImpl.groovy
+++ b/src/groovy/com/grails/cxf/client/WebServiceClientFactoryImpl.groovy
@@ -19,6 +19,7 @@ import org.apache.cxf.transport.http.HTTPConduit
 import org.apache.cxf.transports.http.configuration.HTTPClientPolicy
 
 import javax.xml.namespace.QName
+import javax.xml.ws.BindingProvider
 import java.lang.reflect.*
 
 class WebServiceClientFactoryImpl implements WebServiceClientFactory {
@@ -65,7 +66,7 @@ class WebServiceClientFactoryImpl implements WebServiceClientFactory {
                                              Map<String, Object> requestContext,
                                              Map tlsClientParameters) {
         WSClientInvocationHandler handler = new WSClientInvocationHandler(clientInterface)
-        Object clientProxy = Proxy.newProxyInstance(clientInterface.classLoader, [clientInterface] as Class[], handler)
+        Object clientProxy = Proxy.newProxyInstance(clientInterface.classLoader, [clientInterface, BindingProvider.class] as Class[], handler)
 
         if(serviceEndpointAddress) {
             try {


### PR DESCRIPTION
We are currently attempting to use your plugin to integrate with NetSuite http://www.netsuite.com using their SOAP interface.  This SOAP interface uses a JSESSION Cookie Stored in the web service session to support authentication.  Not a complicated implementation I know but it is the only NetSuite interface we can use.
If we just use straight apache-cxf in Grails with Spring I would create a bean using JaxWsProxyFactoryBean to configure it up and then inject the resulting bean into my application.  Then inside my grails application when I accessed the Client I would be able to call:

BindingProvider bindingProvider = (BindingProvider) myWebServiceClient
bindingProvider.getRequestContext().put(BindingProvider.SESSION_MAINTAIN_PROPERTY, "true")
