### PR TITLE
extended logging for 'wsdl2java' target to see errors

### DIFF
--- a/scripts/Wsdl2java.groovy
+++ b/scripts/Wsdl2java.groovy
@@ -23,6 +23,7 @@ This target needs to be run only upon changes in the upstream API, since it's ar
     wsdls.each { config ->
         if(config?.wsdl) {
             printMessage "Generating java stubs from ${config?.wsdl}"
+            ant.logger.setMessageOutputLevel(org.codehaus.gant.GantState.NORMAL)
             ant.java(classname: 'org.apache.cxf.tools.wsdlto.WSDLToJava') {
                 arg(value: "-verbose")
                 if(config?.client) arg(value: "-client")


### PR DESCRIPTION
- the default log level is ERROR (see org.apache.tools.ant.DefaultLogger)
- but Gant uses log level INFO to log errors when running org.apache.cxf.tools.wsdlto.WSDLToJava
- if everything runs fine the output looks like this:

```
Generating java stubs from grails-app/conf/some.wsdl
     [java] Loading FrontEnd jaxws ...
     [java] Loading DataBinding jaxb ...
     [java] wsdl2java -verbose -d src/java -autoNameResolution -validate grails-app/conf/some.wsdl
Completed wsdl2java
```
- if an error occurs it looks like this:

```
  Generating java stubs from grails-app/conf/some.wsdl
     [java] Loading FrontEnd jaxws ...
     [java] Loading DataBinding jaxb ...
     [java] wsdl2java -verbose -d src/java -autoNameResolution -validate grails-app/conf/some.wsdl
     [java] WSDLToJava Error: ...
     [java] SOME STACKTRACE ...
  Completed wsdl2java
```
