### PR TITLE
Documents PortType->Interface for the clientInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ cxf {
 You may need to use the interface rather than the port type to make your client work:
 
     ...
-    clientInterface = cxf.client.demo.simple.SimpleServiceInterface
+    clientInterface = cxf.client.demo.simple.SimpleInterface
     ...
 
 Note: The [wsdl] node is only used by the wsdl2java target and are not used in wiring the beans at runtime.


### PR DESCRIPTION
For me using the PortType in the clientInterface property didn't work resulting in a not found class when trying to convert the property value from a String to a Class. Changing it to the Interface instead worked nicely.

It may be that PortType should be replaced by interface in the example OR that there is some other kind of WSDL that matches the PortType scenario. 

This pull request may be a solution to issue #43.
